### PR TITLE
Add missing assert messages

### DIFF
--- a/public/features/steps/calculator_steps.py
+++ b/public/features/steps/calculator_steps.py
@@ -2,7 +2,7 @@
 # https://github.com/behave/behave.example
 # License: BSD
 
-# pylint: disable=E0102,E0611,C0103
+# pylint: disable=E0102,E0611,E1102,C0103
 
 from behave import given, register_type, then, when
 
@@ -24,15 +24,15 @@ def step_impl(context):
 
 @when('I add "{x:Number}" and "{y:Number}"')
 def step_impl(context, x, y):
-    assert isinstance(x, int)
-    assert isinstance(y, int)
+    assert isinstance(x, int), f"Value x is not an int: {x}"
+    assert isinstance(y, int), f"Value y is not an int: {x}"
     context.calculator.add2(x, y)
     print(f"Result: {context.calculator.result}")
 
 @then('the calculator returns "{expected:Number}"')
 def step_impl(context, expected):
-    assert isinstance(expected, int)
-    assert context.calculator.result == expected
+    assert isinstance(expected, int), f"Expected value is not an int: {expected}"
+    assert context.calculator.result == expected, f"Unexpected result: {context.calculator.result}"
 
 
 # file:features/steps/calculator.py

--- a/public/features/steps/ninja.py
+++ b/public/features/steps/ninja.py
@@ -2,7 +2,7 @@
 # https://github.com/behave/behave.example
 # License: BSD
 
-# pylint: disable=E0401,E0602,E0611,C0114,C0116,E0102,W0613,W0614,W0401
+# pylint: disable=E0401,E0602,E0611,E1102,C0114,C0116,E0102,W0613,W0614,W0401
 
 from behave import *
 
@@ -15,7 +15,7 @@ def step_the_ninja_encounters_another_opponent(context):
     # -- SETUP/TEARDOWN:
     if hasattr(context, "ninja_fight"):
         # -- VERIFY: Double-call does not occur.
-        assert context.ninja_fight is not None
+        assert context.ninja_fight is not None, "Value for context.ninja_fight should not be None"
     context.ninja_fight = None
 
 @given('the ninja has a {achievement_level}')
@@ -34,7 +34,7 @@ def step_attacked_by(context, opponent):
 def step_the_ninja_should(context, reaction):
     actual_reaction = context.ninja_fight.decision()
     print(f"Reaction: {actual_reaction}")
-    assert reaction == actual_reaction
+    assert reaction == actual_reaction, f"Unexpected reaction: {actual_reaction}"
 
 
 # file:features/steps/ninja_fight.py
@@ -54,8 +54,8 @@ class NinjaFight(object):
         """
         Business logic how a Ninja should react to increase his survival rate.
         """
-        assert self.with_ninja_level is not None
-        assert self.opponent is not None
+        assert self.with_ninja_level is not None, "Value for self.with_ninja_level should not be None"
+        assert self.opponent is not None, "Value for self.opponent should not be None"
         if self.opponent == "Chuck Norris":
             return "run for his life"
         if "black-belt" in self.with_ninja_level:

--- a/public/features/steps/test_support.py
+++ b/public/features/steps/test_support.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0401,E0611,C0114,C0116,E0102,W0613
+# pylint: disable=E0401,E0611,C0114,C0116,E0102,E1102,W0613,W0718
 from behave import step
 from behave.runner import Context
 
@@ -11,4 +11,4 @@ def step_impl(context: Context, error_msg):
         context.execute_steps(context.text)
     except Exception as ex:
         actual_error_msg = repr(ex)
-    assert error_msg in actual_error_msg
+    assert error_msg in actual_error_msg, f"Term '{error_msg}' not found in actual error message"

--- a/public/features/steps/tutorial.py
+++ b/public/features/steps/tutorial.py
@@ -3,7 +3,7 @@
 # https://github.com/behave/behave
 # BSD-2-Clause
 
-# pylint: disable=E0602,E0102,W0613,W0614,W0401
+# pylint: disable=E0602,E0102,E1102,W0613,W0614,W0401
 
 from behave import *
 
@@ -14,8 +14,8 @@ def step_impl(context):
 
 @when('we implement a test')
 def step_impl(context):
-    assert True is not False
+    assert True is not False, "True is not False"
 
 @then('behave will test it for us!')
 def step_impl(context):
-    assert context.failed is False
+    assert context.failed is False, "context.failed is not False"

--- a/public/features/steps/website_steps.py
+++ b/public/features/steps/website_steps.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0611,E0102,W0613,W0622,C0411,C0413
+# pylint: disable=E0611,E0102,E1102,W0613,W0622,C0411,C0413
 from behave import given, step
 
 
@@ -24,7 +24,7 @@ def step_impl(context, username, password):
 @step('I verify valid login for "{name}"')
 def step_impl(context, name):
     server: TestObject = context.server
-    assert server.get_user(context.session_id) is not None
+    assert server.get_user(context.session_id) is not None, "Login failed!"
 
 
 @step('I perform server operation "{operation_name}"')


### PR DESCRIPTION
Behave 1.3 has changed the way it prints assert failures to the log. Add an assert failure message to make sure log output is clear and makes sense.